### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete regular expression for hostnames

### DIFF
--- a/contracts/lib/openzeppelin-contracts/certora/run.js
+++ b/contracts/lib/openzeppelin-contracts/certora/run.js
@@ -48,7 +48,7 @@ if (argv._.length == 0 && !argv.all) {
               if (argv.verbose) console.log(`[${i + 1}/${length}] Running ${conf}`);
               exec(`certoraRun ${conf}`, (error, stdout, stderr) => {
                 const match = stdout.match(
-                  'https://prover.certora.com/output/[a-z0-9]+/[a-z0-9]+[?]anonymousKey=[a-z0-9]+',
+                  'https://prover\.certora\.com/output/[a-z0-9]+/[a-z0-9]+[?]anonymousKey=[a-z0-9]+',
                 );
                 if (error) {
                   console.error(`[ERR] ${conf} failed with:\n${stderr || stdout}`);


### PR DESCRIPTION
Potential fix for [https://github.com/JSONbored/flip-battle/security/code-scanning/1](https://github.com/JSONbored/flip-battle/security/code-scanning/1)

The best way to fix this problem is to escape the `.` characters in the regular expression string so that they match only literal dots, not any character. In particular, in the hostname portion (`prover.certora.com/output/`) the `.` should be written as `\.`. Additionally, since the rest of the regular expression uses brackets (e.g., `[a-z0-9]+`, which should be unchanged), only the dots in the host portion need escaping.

Concretely, edit line 51 in contracts/lib/openzeppelin-contracts/certora/run.js to update the string passed to `stdout.match`, so:
- Every `.` in the hostname portion is replaced with `\.` (i.e., `prover\.certora\.com`).
- The rest of the pattern is left unchanged.

No additional imports or methods are required, as this is a simple pattern fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
