### PR TITLE
Potential fix for code scanning alert no. 7: Shell command built from environment values

### DIFF
--- a/contracts/lib/openzeppelin-contracts/certora/run.js
+++ b/contracts/lib/openzeppelin-contracts/certora/run.js
@@ -12,7 +12,7 @@ const fs = require('fs');
 const pLimit = require('p-limit').default;
 const { hideBin } = require('yargs/helpers');
 const yargs = require('yargs/yargs');
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
 
 const { argv } = yargs(hideBin(process.argv))
   .env('')
@@ -46,7 +46,7 @@ if (argv._.length == 0 && !argv.all) {
           () =>
             new Promise(resolve => {
               if (argv.verbose) console.log(`[${i + 1}/${length}] Running ${conf}`);
-              exec(`certoraRun ${conf}`, (error, stdout, stderr) => {
+              execFile('certoraRun', [conf], (error, stdout, stderr) => {
                 const match = stdout.match(
                   'https://prover\.certora\.com/output/[a-z0-9]+/[a-z0-9]+[?]anonymousKey=[a-z0-9]+',
                 );


### PR DESCRIPTION
Potential fix for [https://github.com/JSONbored/flip-battle/security/code-scanning/7](https://github.com/JSONbored/flip-battle/security/code-scanning/7)

To fix this problem, you must avoid passing potentially unsafe values to the shell via string interpolation. Instead, use an API that allows you to specify the command and its arguments separately, avoiding shell interpretation. In Node.js, this means replacing `child_process.exec` with `child_process.execFile`. Specifically, each call to `exec(`certoraRun ${conf}`)` should be replaced with `execFile('certoraRun', [conf], ...)`, which runs the command directly and passes the argument as a string literal to the executed program, not via the shell. Only file contracts/lib/openzeppelin-contracts/certora/run.js needs changing; you will need to require `execFile` from `child_process` and replace the invocation in line 49 (and provide enough context for any needed destructuring or imports).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
