### PR TITLE
Potential fix for code scanning alert no. 6: Useless regular-expression character escape

### DIFF
--- a/contracts/lib/openzeppelin-contracts/certora/run.js
+++ b/contracts/lib/openzeppelin-contracts/certora/run.js
@@ -48,7 +48,7 @@ if (argv._.length == 0 && !argv.all) {
               if (argv.verbose) console.log(`[${i + 1}/${length}] Running ${conf}`);
               execFile('certoraRun', [conf], (error, stdout, stderr) => {
                 const match = stdout.match(
-                  'https://prover\.certora\.com/output/[a-z0-9]+/[a-z0-9]+[?]anonymousKey=[a-z0-9]+',
+                  'https://prover\\.certora\\.com/output/[a-z0-9]+/[a-z0-9]+[?]anonymousKey=[a-z0-9]+',
                 );
                 if (error) {
                   console.error(`[ERR] ${conf} failed with:\n${stderr || stdout}`);


### PR DESCRIPTION
Potential fix for [https://github.com/JSONbored/flip-battle/security/code-scanning/6](https://github.com/JSONbored/flip-battle/security/code-scanning/6)

The best way to fix this issue is to ensure that, when representing a literal dot character in a regular-expression string (to be passed to `.match()`), you use a double backslash (`\\.`) so that the regular expression receives a single `\.` and matches a literal dot. Concretely, in this file, on line 51, replace each instance of `\.` with `\\.` within the string pattern. This will ensure the regular expression matches literal periods in URLs, rather than any character, and has no other impact on existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
